### PR TITLE
fix: upgrade goreleaser-action to v6 for version 2 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           git push origin ${{ steps.version.outputs.version }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
## 🐛 **Fix GoReleaser Action Compatibility**

### **Problem**
GitHub Actions workflow failed with:
```
Error: only configurations files on version: 1 are supported, yours is version: 2
```

### **Root Cause**
- `.goreleaser.yaml` uses `version: 2` (modern syntax)
- GitHub Actions used `goreleaser-action@v5` (supports v1 only)

### **Solution**
- ✅ Upgrade to `goreleaser-action@v6` (supports v2)
- ✅ Keep modern `version: 2` configuration
- ✅ Maintain all GoReleaser v2 features

### **Expected Result**
- Auto-release v0.1.1 should work
- Homebrew formula should be generated in `homebrew-hexa`
- `brew install hyphaene/hexa` should become functional

**🎯 This should complete our end-to-end GoReleaser + Homebrew setup!**