### PR TITLE
fix: move Homebrew formula to Formula/ directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           git push origin ${{ steps.version.outputs.version }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,7 +54,7 @@ brews:
       branch: main
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
 
-    directory: .
+    directory: Formula
 
     # Create hw symlink → hexa
     install: |


### PR DESCRIPTION
## 🐛 **Fix Homebrew Formula Discovery**

### **Problem**
`brew install hyphaene/hexa` fails with:
```
Warning: No available formula with the name "hexa"
```

### **Root Cause**
Formula placed at tap root (`.`) instead of `Formula/` directory

### **Solution**
- ✅ Change `directory: .` → `directory: Formula`
- ✅ Follows Homebrew conventions
- ✅ Enables `brew install hyphaene/hexa` to work

### **Expected Result**
- New release with formula in `Formula/hexa.rb`
- `brew install hyphaene/hexa` should find the formula
- Public repo ensures assets are downloadable