### PR TITLE
docs(install): add Homebrew installation instructions and tap reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # Hexa CLI
 
 Hexactitude CLI - Unified automation and scripting toolkit
+
+## Installation
+
+### Via Homebrew (recommended)
+
+```bash
+brew install hyphaene/hexa/hexa
+```
+
+Or with the shorter alias `hw`:
+
+```bash
+hw --help
+```
+
+### Manual Installation
+
+Download the latest release from the [releases page](https://github.com/hyphaene/hexa/releases).
+
+## Homebrew Tap
+
+This project uses a custom Homebrew tap for distribution. The tap repository is maintained at:
+[github.com/hyphaene/homebrew-hexa](https://github.com/hyphaene/homebrew-hexa)


### PR DESCRIPTION
## Summary

This PR adds comprehensive installation documentation to the README, including:

- **Homebrew installation** via custom tap `hyphaene/hexa`
- **Manual installation** option with releases page reference
- **Homebrew tap information** with repository link
- **Short alias usage** example (`hw` command)

## Changes Made

- Added Installation section with two installation methods
- Documented the Homebrew tap setup and usage
- Included reference to releases page for manual installation
- Added example usage of the `hw` alias

## Testing

- ✅ Documentation formatting verified
- ✅ Homebrew tap repository reference confirmed
- ✅ Installation instructions are clear and actionable

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change