### PR TITLE
docs(readme): add shell completion installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ brew install hexa
 # Verify installation with both commands
 hexa --help
 hw --help   # Short alias
+
+```
+
+### Shell Completion
+
+```bash
+hexa completion install
+echo 'compdef _hexa hw' >> ~/.zshrc  # Enable completion for the hw alias
+source ~/.zshrc
 ```
 
 ### Manual Installation


### PR DESCRIPTION
# Shell Completion Installation Documentation

## Summary

This PR adds comprehensive shell completion installation instructions to the README, making it easier for users to enable completion for both the `hexa` command and its `hw` alias.

## Changes

- **Added Shell Completion section** to README.md with:
  - `hexa completion install` command for automatic setup
  - Manual alias completion setup: `compdef _hexa hw`
  - Shell reload instruction: `source ~/.zshrc`

## Motivation

The hexa CLI includes shell completion functionality, but users weren't aware of how to enable it. This documentation fills that gap and ensures users can take full advantage of the completion features for both the main command and the short alias.

## Testing

- [x] Verified documentation formatting
- [x] Tested completion commands locally
- [x] Confirmed alias completion works with `compdef _hexa hw`

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change